### PR TITLE
Add Clerk for Startups to Developer Tools & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ If you're building AI products, these credits go directly toward inference, trai
 | **[Linear](https://linear.app/)** | Discounted plans | Startup program | Issue tracking / project mgmt. |
 | **[Notion for Startups](https://www.notion.so/startups)** | $500+ credits (often via partners) | Open / partner-unlocked | Docs, wiki, project mgmt. |
 | **[PostHog](https://posthog.com/startups)** | 1 yr free Growth plan, up to 1.2B events / 200K MTUs | Early-stage | Product analytics. |
+| **[Clerk for Startups](https://clerk.com/startups)** | Clerk Pro features at a discount | Up to 1 year after launch, up to $5M in funding | 50K monthly retained users are already free on every plan |
 
 ---
 


### PR DESCRIPTION
Adds Clerk's startup program to the Developer Tools & Observability table.

- Offer: Clerk Pro features at a discount for early-stage startups
- Eligibility: up to 1 year after launch, up to $5M in venture funding
- Details and application: https://clerk.com/startups

Noted in the Notes column that the 50K monthly retained user free tier applies on every plan regardless, since that's the bigger deal for most early startups.